### PR TITLE
Scope performance and external window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ DISTRIBUTABLES += $(wildcard LICENSE*) res
 
 # If RACK_DIR is not defined when calling the Makefile, default to two levels above
 RACK_DIR ?= ../..
+include $(RACK_DIR)/arch.mk
+
+ifdef ARCH_WIN
+    LDFLAGS += -lopengl32
+endif
 
 # Include the VCV Rack plugin Makefile framework
 include $(RACK_DIR)/plugin.mk

--- a/plugin.json
+++ b/plugin.json
@@ -8,7 +8,7 @@
 	"sourceUrl": "https://github.com/david-c14/ModularFungi",
 	"donateUrl": "https://paypal.me/omricohencomposer",
 	"manualUrl": "https://github.com/david-c14/ModularFungi/blob/master/README.md",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"modules": [
 		{
 			"slug":"Blank1HP",

--- a/src/Scope.cpp
+++ b/src/Scope.cpp
@@ -29,6 +29,11 @@
 #include <atomic>
 #include "ModularFungi.hpp"
 
+// Get the GLFW API.
+#define GLEW_STATIC
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+
 
 ///512 in original scope, 4096 with variable bufferSize
 static const int MAX_BUFFER_SIZE = 4096;
@@ -899,7 +904,7 @@ struct ScopeWidget : ModuleWidget, IPopupWindowOwner {
 
 
 	void step() override {
-		//pop-out window is handled here, I would I ppreferred ScopeDisplay::draw()
+		//pop-out window is handled here, I would have preferred ScopeDisplay::draw()
 		//but this only updates the external window if the ModuleWidget is displayed
 		//zooming and scrolling in the main window can stop rendering of the external
 		//window


### PR DESCRIPTION
 - Improved the performance of the Scope plugin
-  Added options to the context menu for performance varying the size of buffer hence the number of points plotted. 
 - Moved the line type and plot type parameters from the context menu to knobs and cv inputs on the widget
-  Interpolation between linetypes
- Added external window for plotting. When external window open the widget no longer renders the waveform in the VCV ui

@david-c14 

I am unsure if your intention is for me to merge, prepare the release, and submit to the VCV library?