### PR TITLE
Add a check for Widget::visible when preparing to draw lights

### DIFF
--- a/src/LightsOff.cpp
+++ b/src/LightsOff.cpp
@@ -86,7 +86,7 @@ struct LightsOffContainer : widget::Widget {
 				q.pop();
 
 				LightWidget *lw = dynamic_cast<LightWidget*>(w);
-				if (lw) {
+				if (lw && lw->visible) {
 					Vec p1 = lw->getRelativeOffset(Vec(), this);
 					Vec p = getAbsoluteOffset(Vec()).neg();
 					p = p.plus(p1);


### PR DESCRIPTION
This way, if a light is hidden via Widget::hide(), it will not be drawn by LightsOff.