### PR TITLE
LightsOff : Leave lights on for Fundamental Scope's scope display

### DIFF
--- a/src/LightsOff.cpp
+++ b/src/LightsOff.cpp
@@ -79,7 +79,7 @@ struct LightsOffContainer : widget::Widget {
 			
 			const std::string scopename="ScopeDisplay";
 			const std::string analyzername="AnalyzerDisplay";
-			// Draw lights and Fundamental Scope Displays
+			// Draw lights, Fundamental Scope displays and BogAudio analyzer displays
 			Rect viewPort = getViewport(box);
 			std::queue<Widget*> q;
 			q.push(APP->scene->rack->moduleContainer);
@@ -92,7 +92,7 @@ struct LightsOffContainer : widget::Widget {
 				if (!lw)
 				{
 					// Wasn't a LightWidget, so let's make a pretty hacky check if it is the ScopeDisplay from
-					// Fundamental Scope
+					// Fundamental Scope or BogAudio analyzer display
 					
 					std::string widgetname = typeid(*w).name();
 					

--- a/src/LightsOff.cpp
+++ b/src/LightsOff.cpp
@@ -78,6 +78,7 @@ struct LightsOffContainer : widget::Widget {
 			nvgFill(args.vg);
 			
 			const std::string scopename="ScopeDisplay";
+			const std::string analyzername="AnalyzerDisplay";
 			// Draw lights and Fundamental Scope Displays
 			Rect viewPort = getViewport(box);
 			std::queue<Widget*> q;
@@ -95,7 +96,8 @@ struct LightsOffContainer : widget::Widget {
 					
 					std::string widgetname = typeid(*w).name();
 					
-					if (widgetname.find(scopename)!=std::string::npos)
+					if (widgetname.find(scopename)!=std::string::npos ||
+						widgetname.find(analyzername)!=std::string::npos)
 					{
 						widgetToDraw = w;
 					}


### PR DESCRIPTION
Using some RTTI/typeid trickery, it was possible to add detection for the Fundamental Scope scope display widget and leave the "lights on" for that too. This was tested to work on Windows and Mac Os. I don't expect there to be problems on Linux, but might be a good idea for someone test on that anyway.
